### PR TITLE
fix: make this module go install-able

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module subsnipe
+module github.com/dub-flow/subsnipe
 
 go 1.21.5
 


### PR DESCRIPTION
hello and thanks for sharing this cool project!

I had troubles running `go install` "directly" against the remote repo (disregarding the GOPROXY for the sake of the argument), which is my preferred way of downloading+compiling+installing Go things (unless there is a native package).

currently, the module is declared simply as `subsnipe`, which means it won't install when you run `go install github.com/dub-flow/subsnipe@latest`, which is the canonical place to get the module anyway:
```
~ % go install -v github.com/dub-flow/subsnipe@latest
go: downloading github.com/dub-flow/subsnipe v0.1.1
go: github.com/dub-flow/subsnipe@latest: version constraints conflict:
	github.com/dub-flow/subsnipe@v0.1.1: parsing go.mod:
	module declares its path as: subsnipe
	       but was required as: github.com/dub-flow/subsnipe
~ %
```

in case you'd be fine with allowing people to install your project as outlined above, declaring the module's full path in `go.mod` should help, as it's done in this PR.

in any case, thank you.