### PR TITLE
fix: embed version from the VERSION file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY fingerprints ./fingerprints
 RUN go mod download
 
 # Build the Go app
-RUN CGO_ENABLED=0 go build -ldflags="-X main.AppVersion=$(cat VERSION) -s -w" -trimpath -o subsnipe .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o subsnipe .
 
 # Second stage of multi-stage build: run the Go binary
 FROM alpine:latest

--- a/version.go
+++ b/version.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+
+	_ "embed"
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-version"
 )
 
-var AppVersion string = "0.0.0"
-var latestRelease string = "https://github.com/dub-flow/subsnipe/releases/latest"
+//go:embed VERSION
+var AppVersion string
+var latestRelease = "https://github.com/dub-flow/subsnipe/releases/latest"
 
 func NotifyOfUpdates() {
 	client := &http.Client{}
@@ -61,16 +63,9 @@ func NotifyOfUpdates() {
 }
 
 func CheckAppVersion() {
-	if AppVersion == "0.0.0" {
-		version, err := os.ReadFile("VERSION")
-		if err != nil {
-			fmt.Print(err)
-		}
-
-		// manually assign the value from `./VERSION` if it wasn't assigned during compilation already. This makes sure
-		// that also people that run/build the app manually (without compiling the `./VERSION` into the output) get the
-		// appropriate version and aren't unnecessarily prompted to update the tool.
-		AppVersion = string(version)
+	// this should never happen, since we embed the version inside the
+	// application.
+	if AppVersion == "" {
+		AppVersion = "0.0.0-unknown"
 	}
-	// if the AppVersion is not "0.0.0" at this point, it means it has been set when compiling the app so we just leave that
 }


### PR DESCRIPTION
this PR prevents errors like: "open VERSION: no such file or directoryCurrent version:", which currently happen after #1.

![image](https://github.com/user-attachments/assets/1c75b683-1aaf-4872-aa7f-0452d9a2d13f)

it is the inevitable side-effect of the program looking for the `VERSION` file in `$PWD`, which it most probably does not find if you just `go install` it.

now no matter whether `go run`-ning or `go install`-ing the program, the version would be embedded inside the application automatically.