### PR TITLE
feat: drop dig dependency

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,9 +200,12 @@ func checkCNAMEs(subdomainsFilePath string) {
 // Performs a CNAME query for a given domain and sends the result to the results channel
 func queryAndSendCNAME(domain string, results chan<- cnameResult) {
 	cname, err := net.LookupCNAME(domain)
-	if err != nil || cname == "" {
-		results <- cnameResult{domain: domain, err: fmt.Errorf("no CNAME record found: %w", err)}
-	} else {
+	switch {
+	case err != nil:
+		results <- cnameResult{domain: domain, err: fmt.Errorf("error obtaining CNAME records: %w", err)}
+	case cname == domain+"." || cname == "": // net.LookupCNAME formats domain with the dot at the end, hence the first condition.
+		results <- cnameResult{domain: domain, err: fmt.Errorf("no CNAME records found")}
+	default:
 		// Log the found CNAME
 		log.Infof("CNAME found for %s is: %s", domain, strings.TrimSpace(cname))
 		results <- cnameResult{domain: domain, cname: strings.TrimSpace(cname)}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/fatih/color"

--- a/utils.go
+++ b/utils.go
@@ -22,12 +22,6 @@ func printIntro() {
 	color.Green("##################################\n\n")
 }
 
-// Checks if the 'dig' command is available on the system
-func checkDigAvailable() bool {
-    _, err := exec.LookPath("dig")
-    return err == nil
-}
-
 // Checks if https://raw.githubusercontent.com/EdOverflow/can-i-take-over-xyz/master/fingerprints.json has been updated. If so,
 // our local copy gets updated too
 func updateFingerprints() (bool, error) {


### PR DESCRIPTION
I am not sure whether there was a specific reason to issue the request for a `CNAME` using `dig`, but this PR drops the requirement for it.

`dig` is still present in the docker image, though, but that could still be useful for potential troubleshooting or sth..
anyway, I didn't touch it, but I could if you think it would make more sense to drop the whole layer there.

### TODO
* [x] verify that the behaviour is correct (and/or unchanged)